### PR TITLE
Export AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

### DIFF
--- a/bin/awsenv-init
+++ b/bin/awsenv-init
@@ -99,8 +99,8 @@ function exportAwsCredentials()
     local ec2Cert="$(globSingleFile "$ENVIRONMENT/cert-")"
     local ec2PrivateKey="$(globSingleFile "$ENVIRONMENT/pk-")"
     local awsCredentialFile="$(globSingleFile "$ENVIRONMENT/credentials")"
-    local ec2AccessKey="$(grep "AWSAccessKeyId" "$awsCredentialFile" | cut -d"=" -f2)"
-    local ec2SecretKey="$(grep "AWSSecretKey"   "$awsCredentialFile" | cut -d"=" -f2)"
+    local awsAccessKey="$(grep "AWSAccessKeyId" "$awsCredentialFile" | cut -d"=" -f2)"
+    local awsSecretKey="$(grep "AWSSecretKey"   "$awsCredentialFile" | cut -d"=" -f2)"
 
     echo "export AWS_CREDENTIAL_FILE='$awsCredentialFile'"
 
@@ -121,9 +121,12 @@ function exportAwsCredentials()
     fi
 
     echo ""
+    echo "export AWS_ACCESS_KEY_ID='$awsAccessKey'"
+    echo "export AWS_SECRET_ACCESS_KEY='$awsSecretKey'"
+    echo ""
     echo "# EC2 still needs the keys as separate variables"
-    echo "export EC2_ACCESS_KEY='$ec2AccessKey'"
-    echo "export EC2_SECRET_KEY='$ec2SecretKey'"
+    echo "export EC2_ACCESS_KEY='$awsAccessKey'"
+    echo "export EC2_SECRET_KEY='$awsSecretKey'"
 }
 
 function exportAwsIdentityFile()


### PR DESCRIPTION
I've got some other ideas in mind, but they might raise some discussion, so here's a quickie I'd like to get out of the way.

This naming scheme is used by the new official [aws-cli client](https://github.com/aws/aws-cli), so hopefully it is becoming somewhat of a standard. It stems from the underlying boto Python library, so incidentally it automatically serves other tools like Ansible too.
