### PR TITLE
Add importing local credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ below
 2. Configures various variables required by the [AWS][] tools:
     * Credential variables (e.g. `AWS_CREDENTIAL_FILE`)
     * Variables regarding the used identity file (e.g. `AWS_IDENTITY_FILE`)
-    * Try to define `JAVA_HOME`, if not already set
 3. Add the used identity file to the `ssh-agent`
 
 Run `awsenv init -` for yourself to see exactly what happens under the hood.
@@ -113,8 +112,11 @@ should be able to setup all required files without any problems.
 
     $ awsenv import git git://github.com/michaelcontento/awsenv-example-env.git example
 
-Currently only environments stored as [Git][] repository are supported. But you 
-can help to expand this list by simply creating a new executable named 
+Import also supports importing your local ` ~/.aws/credentials ` file which is being used by [AWS CLI](https://aws.amazon.com/cli/). It only supports importing your keys at the moment.
+
+    $ awsenv import local
+
+You can help to expand this list by simply creating a new executable named
 `awsenv-import-<TYPE>`. Pull requests are welcome!
 
 ## Development

--- a/bin/awsenv-import
+++ b/bin/awsenv-import
@@ -3,7 +3,7 @@
 set -e
 [ -n "$AWSENV_DEBUG" ] && set -x
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
     awsenv version
     echo "usage: awsenv import <type> <path> [alias]"
     echo ""

--- a/bin/awsenv-import-git
+++ b/bin/awsenv-import-git
@@ -3,11 +3,11 @@
 set -e
 [ -n "$AWSENV_DEBUG" ] && set -x
 
-if [ $# -eq 0 ]; then
+if [ $# -lt 2 ]; then
     awsenv version
     echo "usage: awsenv import-git <path> [alias]"
     echo ""
-    echo "error: no arguments given." >&2
+    echo "error: not enough arguments given." >&2
     exit 1
 fi
 

--- a/bin/awsenv-import-local
+++ b/bin/awsenv-import-local
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+[ -n "$AWSENV_DEBUG" ] && set -x
+
+if [ $# -eq 0 ]; then
+    awsenv version
+    echo "usage: awsenv import-local <path>"
+    echo ""
+    echo "error: no arguments given." >&2
+    exit 1
+fi
+
+AWSENV_ROOT="$(awsenv root)"
+cd "$AWSENV_ROOT/envs"
+
+PATH_="${1:-$HOME/.aws/credentials}"
+
+PROFILES="$(grep -E '\[|\]' "$PATH_" | tr -d '[]')"
+
+echo "importing shared credentials from $PATH_"
+
+for PROFILE in $PROFILES; do
+    [ ! -d "$PROFILE" ] && mkdir "$PROFILE"
+    echo AWSAccessKeyId=$(aws configure get aws_access_key_id --profile $PROFILE) > "$PROFILE/credentials"
+    echo AWSSecretKey=$(aws configure get aws_secret_access_key --profile $PROFILE) >> "$PROFILE/credentials"
+    echo "export EC2_REGION=$(aws configure get region --profile $PROFILE)" > "$PROFILE/config"
+done
+
+awsenv version
+echo "notice: the environment has to be selected / activated."
+echo "hint:   use 'awsenv list' list environment"
+echo "hint:   or switch for current session only with: eval \"\$(awsenv init <environment>)\""

--- a/bin/awsenv-init
+++ b/bin/awsenv-init
@@ -128,31 +128,6 @@ function exportAwsIdentityFile()
     fi
 }
 
-function exportJavaHome()
-{
-    echo ""
-    echo "# Try to ensure a valid JAVA_HOME"
-    if [ "$JAVA_HOME" != "" ]; then
-        echo "# ... already set and we obey"
-        return
-    fi
-
-    local osxJavaHome="/System/Library/Frameworks/JavaVM.framework/Home/"
-    if [ -d "$osxJavaHome" ]; then
-        echo "export JAVA_HOME='$osxJavaHome'"
-        return
-    fi
-
-    local detected=$(readlink -f "$(which java)" | sed "s:jre/bin/java::")
-    if [ -d "$detected" ]; then
-        echo "export JAVA_HOME='$detected'"
-        return
-    fi
-
-    echo "error: unable to detect JAVA_HOME" >&2
-    exit 1
-}
-
 function exportCustomConfig()
 {
     echo ""
@@ -172,6 +147,5 @@ function exportCustomConfig()
 exportAwsEnvGlobals
 exportAwsCredentials
 exportAwsIdentityFile
-exportJavaHome
 exportCustomConfig
 


### PR DESCRIPTION
I was missing the last mile for the tool to be really useful for me. Since I don't want to maintain my credentials in two places I wrote this tiny import module that creates ` envs ` based on profiles in AWS CLI shared config file.

And yes I removed the ` JAVA_HOME ` setup as well ;)